### PR TITLE
Add bash script to download necessary files for Colab

### DIFF
--- a/pa3.ipynb
+++ b/pa3.ipynb
@@ -110,6 +110,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we'll download some extra files that we need, if we don't already have them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "if [[ ! -d \"./data\" ]]\n",
+    "then\n",
+    "    echo \"Missing extra files (this probably means you're running on Google Colab). Downloading...\"\n",
+    "    git clone https://github.com/cs124/pa3-ir.git\n",
+    "    cp -r ./pa3-ir/{data,porter_stemmer.py} .\n",
+    "fi"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
I have been running these notebooks in Colab instead of Jupyter notebook and I have had to include a script like this for past assignments:

```
%%bash

if [[ ! -d "./data" ]]
then
    echo "Missing extra files (this probably means you're running on Google Colab). Downloading..."
    git clone https://github.com/cs124/pa3-ir.git
    cp -r ./pa3-ir/{data,porter_stemmer.py} .
fi
```

This script is present in pa0 and pa4.